### PR TITLE
Fix swapped ETM/ITM fields in SVD parser

### DIFF
--- a/hw/cortexm/svd.c
+++ b/hw/cortexm/svd.c
@@ -531,14 +531,14 @@ void svd_process_cpu(JSON_Object *svd, CortexMCoreCapabilities *core)
         core->has_fpu = false;
     }
 
-    str = json_object_get_string(cpu, "qemuItmPresent");
+    str = json_object_get_string(cpu, "qemuEtmPresent");
     if (str != NULL) {
         core->has_etm = svd_parse_bool(str);
     } else {
         core->has_etm = false;
     }
 
-    str = json_object_get_string(cpu, "qemuEtmPresent");
+    str = json_object_get_string(cpu, "qemuItmPresent");
     if (str != NULL) {
         core->has_itm = svd_parse_bool(str);
     } else {


### PR DESCRIPTION
It appears that the ETM and ITM fields get mixed up when parsing the SVD
file. This commit puts them back in order. I *haven't* checked for any
files that may have been generated incorrectly with the old version.