### PR TITLE
Implement very basic USART stub and fix compatibility

### DIFF
--- a/hw/cortexm/gpio-led.c
+++ b/hw/cortexm/gpio-led.c
@@ -233,7 +233,9 @@ static void gpio_led_instance_init_callback(Object *obj)
     // A helper class is gpio_led_connect().
 
     // Explicitly start with the graphic context cleared.
+#ifdef CONFIG_SDL
     cortexm_graphic_led_clear_graphic_context(&(state->led_graphic_context));
+#endif /* defined(CONFIG_SDL) */
 }
 
 static void gpio_led_realize_callback(DeviceState *dev, Error **errp)

--- a/hw/cortexm/graphic.c
+++ b/hw/cortexm/graphic.c
@@ -31,6 +31,8 @@
 #include "verbosity.h"
 #endif
 
+#ifdef CONFIG_SDL
+
 // ----------------------------------------------------------------------------
 
 static void cortexm_graphic_board_init_graphic_context(
@@ -718,3 +720,22 @@ static void cortexm_graphic_led_turn(BoardGraphicContext *board_graphic_context,
 
 // ----------------------------------------------------------------------------
 
+#else
+
+bool cortexm_graphic_board_is_graphic_context_initialised(
+        BoardGraphicContext *board_graphic_context)
+{
+    return false;
+}
+
+int cortexm_graphic_enqueue_event(int code, void *data1, void *data2)
+{
+    return 0;
+}
+
+void cortexm_graphic_board_add_button(
+        BoardGraphicContext *board_graphic_context, ButtonState *button_state)
+{
+}
+
+#endif

--- a/hw/cortexm/mcu.c
+++ b/hw/cortexm/mcu.c
@@ -111,7 +111,7 @@ static void cortexm_mcu_realize_callback(DeviceState *dev, Error **errp)
         const char *svd_full_name = qemu_find_file(QEMU_FILE_TYPE_DEVICES,
                 capabilities->svd_file_name);
         if (svd_full_name == NULL) {
-            error_printf("JSON SVD file '%s' not found.\n", svd_full_name);
+            error_printf("JSON SVD file '%s' not found.\n", capabilities->svd_file_name);
             exit(1);
         }
 

--- a/hw/cortexm/mcu.c
+++ b/hw/cortexm/mcu.c
@@ -251,7 +251,7 @@ static void cortexm_mcu_realize_callback(DeviceState *dev, Error **errp)
     if (sram_size_kb == 0) {
         /* First try the board definition */
         /* To be noted, setting -m affects this value. */
-        sram_size_kb = machine->ram_size / (1024 * 1024);
+        sram_size_kb = machine->ram_size / 1024;
     }
     if (sram_size_kb == 0) {
         /* Otherwise use the MCU value */

--- a/include/hw/cortexm/graphic.h
+++ b/include/hw/cortexm/graphic.h
@@ -94,9 +94,11 @@ typedef struct {
 
 // Storage for LED graphic context, stored in GPIOLEDState
 typedef struct {
+#ifdef CONFIG_SDL
     SDL_Rect rectangle;
     SDL_Surface *crop_off;
     SDL_Surface *crop_on;
+#endif
 } LEDGraphicContext;
 
 // ----------------------------------------------------------------------------

--- a/util/memfd.c
+++ b/util/memfd.c
@@ -36,15 +36,6 @@
 #elif defined CONFIG_LINUX
 #include <sys/syscall.h>
 #include <asm/unistd.h>
-
-static int memfd_create(const char *name, unsigned int flags)
-{
-#ifdef __NR_memfd_create
-    return syscall(__NR_memfd_create, name, flags);
-#else
-    return -1;
-#endif
-}
 #endif
 
 #ifndef MFD_CLOEXEC

--- a/vl.c
+++ b/vl.c
@@ -40,7 +40,6 @@
 #include "qemu/thread.h"
 #include "qemu/log.h"
 
-#include <SDL.h>
 int qemu_main(int argc, char **argv, char **envp);
 
 #include <hw/cortexm/graphic.h>
@@ -99,7 +98,9 @@ int main(int argc, char **argv)
 
 #endif /* !defined(USE_GRAPHIC_POLL_EVENT) */
 
+#ifdef CONFIG_SDL
     cortexm_graphic_quit();
+#endif
 
     qemu_log_mask(LOG_FUNC, "%s() done.\n", __FUNCTION__);
 
@@ -4809,7 +4810,9 @@ int main(int argc, char **argv, char **envp)
 
 #else
 
+#ifdef CONFIG_SDL
     cortexm_graphic_start(nographic);
+#endif
 
 #endif /* !defined(CONFIG_GNU_MCU_ECLIPSE) */
 


### PR DESCRIPTION
This patch set makes the following:

- USART can provide input and output over TCP and output over stdio. The implementation is not exactly following the spec but is better than nothing.
- SDL library is made optional.
- `-m` argument is correctly handled, and 32M now means 32 MB of SRAM rather than 32 KB as before.
- Linux compilation is fixed. 