### PR TITLE
Fix error printing on missing files

### DIFF
--- a/hw/cortexm/mcu.c
+++ b/hw/cortexm/mcu.c
@@ -111,7 +111,7 @@ static void cortexm_mcu_realize_callback(DeviceState *dev, Error **errp)
         const char *svd_full_name = qemu_find_file(QEMU_FILE_TYPE_DEVICES,
                 capabilities->svd_file_name);
         if (svd_full_name == NULL) {
-            error_printf("JSON SVD file '%s' not found.\n", svd_full_name);
+            error_printf("JSON SVD file '%s' not found.\n", capabilities->svd_file_name);
             exit(1);
         }
 


### PR DESCRIPTION
`svd_full_name` is `NULL`, so there is no reason to print it. Should rather print the file name we searched for (`capabilities→svd_file_name`).