### PR TITLE
Fix calculating kilobytes from bytes in memory arg parsing

### DIFF
--- a/hw/cortexm/mcu.c
+++ b/hw/cortexm/mcu.c
@@ -251,7 +251,7 @@ static void cortexm_mcu_realize_callback(DeviceState *dev, Error **errp)
     if (sram_size_kb == 0) {
         /* First try the board definition */
         /* To be noted, setting -m affects this value. */
-        sram_size_kb = machine->ram_size / (1024 * 1024);
+        sram_size_kb = machine->ram_size / 1024;
     }
     if (sram_size_kb == 0) {
         /* Otherwise use the MCU value */


### PR DESCRIPTION
`machine->ram_size` contains memory size in bytes, to get kilobytes one must divide by 1024. The mistake makes `-m 1M` command line argument behave as if only 1 KB was allocated for the board.