### PR TITLE
Make SDL optional

### DIFF
--- a/hw/cortexm/button-gpio.c
+++ b/hw/cortexm/button-gpio.c
@@ -61,7 +61,9 @@ void button_gpio_create_from_info(Object *parent, ButtonGPIOInfo *info_array,
                     info->gpio_bit);
         }
 
+#if defined(CONFIG_SDL)
         cortexm_graphic_board_add_button(graphic_context, BUTTON_STATE(button));
+#endif /* defined(CONFIG_SDL) */
 
 #if defined(CONFIG_VERBOSE)
         if (verbosity_level >= VERBOSITY_DETAILED) {

--- a/hw/cortexm/button-reset.c
+++ b/hw/cortexm/button-reset.c
@@ -44,7 +44,9 @@ void button_reset_create_from_info(Object *parent, ButtonResetInfo *info,
 
     cm_object_realize(button);
 
+#if defined(CONFIG_SDL)
     cortexm_graphic_board_add_button(graphic_context, BUTTON_STATE(button));
+#endif /* defined(CONFIG_SDL) */
 
 #if defined(CONFIG_VERBOSE)
     if (verbosity_level >= VERBOSITY_DETAILED) {

--- a/hw/cortexm/gpio-led.c
+++ b/hw/cortexm/gpio-led.c
@@ -233,7 +233,9 @@ static void gpio_led_instance_init_callback(Object *obj)
     // A helper class is gpio_led_connect().
 
     // Explicitly start with the graphic context cleared.
+#ifdef CONFIG_SDL
     cortexm_graphic_led_clear_graphic_context(&(state->led_graphic_context));
+#endif /* defined(CONFIG_SDL) */
 }
 
 static void gpio_led_realize_callback(DeviceState *dev, Error **errp)

--- a/hw/cortexm/graphic.c
+++ b/hw/cortexm/graphic.c
@@ -31,6 +31,8 @@
 #include "verbosity.h"
 #endif
 
+#ifdef CONFIG_SDL
+
 // ----------------------------------------------------------------------------
 
 static void cortexm_graphic_board_init_graphic_context(
@@ -718,3 +720,4 @@ static void cortexm_graphic_led_turn(BoardGraphicContext *board_graphic_context,
 
 // ----------------------------------------------------------------------------
 
+#endif

--- a/include/hw/cortexm/graphic.h
+++ b/include/hw/cortexm/graphic.h
@@ -94,9 +94,11 @@ typedef struct {
 
 // Storage for LED graphic context, stored in GPIOLEDState
 typedef struct {
+#ifdef CONFIG_SDL
     SDL_Rect rectangle;
     SDL_Surface *crop_off;
     SDL_Surface *crop_on;
+#endif
 } LEDGraphicContext;
 
 // ----------------------------------------------------------------------------

--- a/target-arm/arm-semi.c
+++ b/target-arm/arm-semi.c
@@ -678,7 +678,7 @@ target_ulong do_arm_semihosting(CPUARMState *env)
         }
 #endif
 
-#if defined(CONFIG_GNU_MCU_ECLIPSE)
+#if defined(CONFIG_GNU_MCU_ECLIPSE) && defined(CONFIG_SDL)
 
         CortexMBoardState *board = cortexm_board_get();
         if (board != NULL) {

--- a/vl.c
+++ b/vl.c
@@ -40,7 +40,6 @@
 #include "qemu/thread.h"
 #include "qemu/log.h"
 
-#include <SDL.h>
 int qemu_main(int argc, char **argv, char **envp);
 
 #include <hw/cortexm/graphic.h>
@@ -99,7 +98,9 @@ int main(int argc, char **argv)
 
 #endif /* !defined(USE_GRAPHIC_POLL_EVENT) */
 
+#ifdef CONFIG_SDL
     cortexm_graphic_quit();
+#endif
 
     qemu_log_mask(LOG_FUNC, "%s() done.\n", __FUNCTION__);
 
@@ -4809,7 +4810,9 @@ int main(int argc, char **argv, char **envp)
 
 #else
 
+#ifdef CONFIG_SDL
     cortexm_graphic_start(nographic);
+#endif
 
 #endif /* !defined(CONFIG_GNU_MCU_ECLIPSE) */
 


### PR DESCRIPTION
Do not require SDL to build qemu. At the cost of disabling the visual interface (leds, buttons, and such) this allows building QEMU on platforms without SDL dependency and using interfaces like serial.