### PR TITLE
Fix Linux compilation

### DIFF
--- a/util/memfd.c
+++ b/util/memfd.c
@@ -36,15 +36,6 @@
 #elif defined CONFIG_LINUX
 #include <sys/syscall.h>
 #include <asm/unistd.h>
-
-static int memfd_create(const char *name, unsigned int flags)
-{
-#ifdef __NR_memfd_create
-    return syscall(__NR_memfd_create, name, flags);
-#else
-    return -1;
-#endif
-}
 #endif
 
 #ifndef MFD_CLOEXEC


### PR DESCRIPTION
`memfd_create` is provided by all relatively modern Linux distributions. Compiling QEMU on Debian 10 gives me a compiler error "static declaration follows non-static declaration for `memfd_create`".